### PR TITLE
feat: unified error envelope & structured JSON logging

### DIFF
--- a/daemon/codechat/cli.py
+++ b/daemon/codechat/cli.py
@@ -3,6 +3,8 @@ import os
 import click
 import requests
 from codechat.server import serve
+import structlog
+logger = structlog.get_logger(__name__)
 
 @click.group()
 def main():
@@ -42,10 +44,10 @@ def set(key: str, value: str):
         server_url = "http://localhost:16005/admin/reload-config"
         response = requests.post(server_url, timeout=5) # Add a timeout
         response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
-        print("Successfully signaled server to reload configuration.")
+        logger.info("Successfully signaled server to reload configuration.")
     except requests.exceptions.RequestException as e:
-        print(f"Warning: Could not signal the running server to reload config: {e}")
-        print("The configuration file was updated, but you may need to restart the server manually.")
+        logger.info(f"Warning: Could not signal the running server to reload config: {e}")
+        logger.info("The configuration file was updated, but you may need to restart the server manually.")
 
 
 if __name__ == '__main__':

--- a/daemon/codechat/errors.py
+++ b/daemon/codechat/errors.py
@@ -1,0 +1,42 @@
+# codechat/errors.py
+from fastapi import Request, HTTPException
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+import traceback
+import structlog  # we’ll replace prints later
+
+logger = structlog.get_logger(__name__)
+
+class ErrorDetail(BaseModel):
+    code: str
+    msg: str
+
+class ErrorEnvelope(BaseModel):
+    error: ErrorDetail
+
+def add_global_error_handlers(app):
+    @app.exception_handler(HTTPException)
+    async def http_exc_handler(request: Request, exc: HTTPException):
+        # Use exc.detail or map to a code if you have enums
+        envelope = ErrorEnvelope(
+            error=ErrorDetail(code=getattr(exc, "code", "HTTP_ERROR"), msg=str(exc.detail))
+        )
+        return JSONResponse(status_code=exc.status_code, content=envelope.dict())
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_exc_handler(request: Request, exc: RequestValidationError):
+        logger.warning("Validation error", errors=exc.errors())
+        envelope = ErrorEnvelope(
+            error=ErrorDetail(code="VALIDATION_ERR", msg="Invalid request payload")
+        )
+        return JSONResponse(status_code=422, content=envelope.dict())
+
+    @app.exception_handler(Exception)
+    async def generic_exc_handler(request: Request, exc: Exception):
+        # Log full stack for ops
+        logger.error("Unhandled exception", stack=traceback.format_exc())
+        envelope = ErrorEnvelope(
+            error=ErrorDetail(code="UNEXPECTED_ERR", msg="An internal server error occurred")
+        )
+        return JSONResponse(status_code=500, content=envelope.dict())

--- a/daemon/codechat/logging.py
+++ b/daemon/codechat/logging.py
@@ -1,0 +1,52 @@
+# daemon/codechat/logging.py
+
+import logging
+import os
+import structlog
+import uuid
+from starlette.middleware.base import BaseHTTPMiddleware
+from structlog.contextvars import bind_contextvars, reset_contextvars, merge_contextvars
+
+def setup_logging(cfg: dict):
+    """
+    Configure both stdlib logging (for uvicorn, starlette, etc.)
+    and structlog for JSON output.
+    """
+    # determine level: config overrides ENV
+    lvl = cfg.get("log.level") or os.getenv("CODECHAT_LOG_LEVEL", "info")
+    level = lvl.upper()
+
+    # stdlib root logger
+    logging.basicConfig(
+        format="%(message)s",
+        level=getattr(logging, level, logging.INFO),
+    )
+
+    structlog.configure(
+        processors=[
+            merge_contextvars,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer(),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        # 1) reset any leftover context
+        reset_contextvars()
+        # 2) generate or read an incoming X-Request-ID header
+        req_id = request.headers.get("x-request-id", str(uuid.uuid4()))
+        # 3) bind it (and any other top-level fields) for this request
+        bind_contextvars(request_id=req_id, path=request.url.path, method=request.method)
+        # 4) call the endpoint
+        response = await call_next(request)
+        # 5) echo the ID back in the response
+        response.headers["X-Request-ID"] = req_id
+        return response

--- a/daemon/codechat/prompt.py
+++ b/daemon/codechat/prompt.py
@@ -2,6 +2,8 @@ from typing import List
 from google.genai import types
 
 from codechat.models import ChatMessage, ProviderType
+import structlog 
+logger = structlog.get_logger(__name__)
 
 
 class PromptManager:
@@ -17,7 +19,7 @@ class PromptManager:
         """Route to the provider‐specific formatter."""
         fmt = self._formatters.get(provider)
         if not fmt:
-            # Should never happen thanks to __init__ guard
+            logger.error(f"No prompt formatter for provider '{provider}'")            
             raise ValueError(f"No prompt formatter for provider '{provider}'")
         return fmt(history, instruction)
     

--- a/daemon/codechat/server.py
+++ b/daemon/codechat/server.py
@@ -3,8 +3,13 @@ from codechat.indexer import Indexer
 from codechat.watcher import Watcher
 from codechat.llm_router import LLMRouter
 from codechat.models import QueryRequest
+from codechat.errors import add_global_error_handlers
 
 app = FastAPI(title="CodeChat Daemon")
+
+# install our unified handlers before anything else
+add_global_error_handlers(app)
+
 
 # instantiate core components
 indexer = Indexer()

--- a/daemon/codechat/server.py
+++ b/daemon/codechat/server.py
@@ -4,23 +4,31 @@ from codechat.watcher import Watcher
 from codechat.llm_router import LLMRouter
 from codechat.models import QueryRequest
 from codechat.errors import add_global_error_handlers
+from codechat.logging import setup_logging, RequestIDMiddleware
+import structlog
 
 app = FastAPI(title="CodeChat Daemon")
 
 # install our unified handlers before anything else
 add_global_error_handlers(app)
 
+# ---- structured logging setup ----
+# load config early so we can pass it into setup_logging
+router = LLMRouter()            # router loads cfg in its ctor
+setup_logging(router.cfg)
+app.add_middleware(RequestIDMiddleware)
 
 # instantiate core components
 indexer = Indexer()
 watcher = Watcher(indexer)
-router = LLMRouter()
 
 # background tasks
 @app.on_event("startup")
 def startup_tasks():
     # start filesystem watcher
     watcher.start()
+    struct_logger = structlog.get_logger("server.startup")
+    struct_logger.info("Filesystem watcher started", path=".")
 
 # HTTP endpoints (future REST/gRPC)
 @app.get("/health")
@@ -38,17 +46,25 @@ async def reload_config():
     """
     Triggers the LLMRouter to reload its configuration from the file.
     """
+    logger = structlog.get_logger("server.reload_config")
     try:
-        print("Reloading configuration...")
+        logger.info("Reloading configuration...")
         router.set_config() # Call set_config on the existing instance
-        print("Configuration reloaded.")
+        logger.info("Configuration reloaded.")
         return {"message": "Configuration reloaded successfully"}
     except Exception as e:
-        print(f"Error reloading configuration: {e}")
+        logger.error("Error reloading configuration?", exception=str(e))
         return {"status" : "error", "message": str(e)}
 
 
 
 def serve(host: str = '127.0.0.1', port: int = 5005):
     import uvicorn
-    uvicorn.run(app, host=host, port=port)
+    # disable uvicorn’s own access logs in favor of our structured output
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        log_config=None,
+        access_log=False,
+    )

--- a/daemon/pyproject.toml
+++ b/daemon/pyproject.toml
@@ -21,6 +21,7 @@ anthropic = "^0.49"
 google-genai="^1.11"
 tree-sitter="^0.24"
 tree_sitter_languages="^1.10"
+structlog="^25.3"
 
 [tool.poetry.scripts]
 codechat = "codechat.cli:main"

--- a/httptest/tests.http
+++ b/httptest/tests.http
@@ -33,3 +33,11 @@ Content-Type: application/json
 }
 
 
+### Bad JSON → 422 with VALIDATION_ERR
+POST http://localhost:16005/query
+Content-Type: application/json
+
+{ this is not valid json }
+
+### Health endpoint still works
+GET http://localhost:16005/health


### PR DESCRIPTION
Unified Error Envelope (Task #1)

    Added codechat/errors.py with ErrorDetail & ErrorEnvelope Pydantic models

    Globally handles:

        HTTPException → wraps into { error: { code, msg } }

        RequestValidationError → 422 + VALIDATION_ERR

        Exception → 500 + UNEXPECTED_ERR (with stack‐trace logged)

    Hooked add_global_error_handlers(app) immediately after app = FastAPI(...)

Structured JSON Logging (Task #2)

    Added structlog dependency and codechat/logging.py helper

    setup_logging(cfg) configures stdlib + structlog (ISO timestamps, log-level, JSON output)

    Updated serve() to disable uvicorn’s text access log (access_log=False)

    Replaced all print(...) calls with logger = structlog.get_logger(__name__) + .info/.warn/.error

    Configurable via CODECHAT_LOG_LEVEL env or config.json
