### PR TITLE
Ensure FunctionExecutor shuts down cleanly

### DIFF
--- a/daemon/codechat/functions/executor.py
+++ b/daemon/codechat/functions/executor.py
@@ -19,6 +19,22 @@ class FunctionExecutor:
         self._pool = ThreadPoolExecutor(max_workers=max_workers)
         self._max_output_bytes = max_output_bytes
 
+    def close(self) -> None:
+        """Shut down the underlying thread pool."""
+        self._pool.shutdown(wait=True)
+
+    def __enter__(self) -> "FunctionExecutor":  # noqa: D401 - part of context manager
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: D401 - part of context manager
+        self.close()
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def _truncate_output(self, value: Any) -> Any:
         try:
             data = value if isinstance(value, (bytes, bytearray)) else str(value).encode("utf-8", errors="replace")

--- a/daemon/codechat/llm_router.py
+++ b/daemon/codechat/llm_router.py
@@ -122,55 +122,55 @@ class LLMRouter:
                     yield chunk
                 return
 
-            executor = FunctionExecutor()
-            ctx = ExecutionContext(root=self.indexer.root, indexer=self.indexer)
-            work_req = deepcopy(req)
+            with FunctionExecutor() as executor:
+                ctx = ExecutionContext(root=self.indexer.root, indexer=self.indexer)
+                work_req = deepcopy(req)
 
-            max_steps = 3
-            steps = 0
-            final_text = ""
+                max_steps = 3
+                steps = 0
+                final_text = ""
 
-            while steps < max_steps:
-                steps += 1
-                result = provider_instance.invoke_with_tools(work_req, functions)  # type: ignore[attr-defined]
-                if "function_calls" not in result:
-                    final_text = result.get("text", "")
-                    break
+                while steps < max_steps:
+                    steps += 1
+                    result = provider_instance.invoke_with_tools(work_req, functions)  # type: ignore[attr-defined]
+                    if "function_calls" not in result:
+                        final_text = result.get("text", "")
+                        break
 
-                calls: list[FunctionCall] = result["function_calls"]
-                if not calls:
-                    final_text = ""
-                    break
+                    calls: list[FunctionCall] = result["function_calls"]
+                    if not calls:
+                        final_text = ""
+                        break
 
-                # Execute and append results
-                lines: list[str] = []
-                for call in calls:
-                    res = executor.execute_function(call, ctx)
-                    if res.success:
-                        out_text = f"[{res.name}]\n{res.output}"
-                        lines.append(out_text)
-                        # Stream tool output to client as we go
-                        for i in range(0, len(out_text), 200):
-                            yield json.dumps({"token": out_text[i:i+200], "finish": False})
-                    else:
-                        err_text = f"[{res.name}] ERROR: {res.error}"
-                        lines.append(err_text)
-                        for i in range(0, len(err_text), 200):
-                            yield json.dumps({"token": err_text[i:i+200], "finish": False})
-                tool_msg = "\n\n".join(lines)
+                    # Execute and append results
+                    lines: list[str] = []
+                    for call in calls:
+                        res = executor.execute_function(call, ctx)
+                        if res.success:
+                            out_text = f"[{res.name}]\n{res.output}"
+                            lines.append(out_text)
+                            # Stream tool output to client as we go
+                            for i in range(0, len(out_text), 200):
+                                yield json.dumps({"token": out_text[i:i+200], "finish": False})
+                        else:
+                            err_text = f"[{res.name}] ERROR: {res.error}"
+                            lines.append(err_text)
+                            for i in range(0, len(err_text), 200):
+                                yield json.dumps({"token": err_text[i:i+200], "finish": False})
+                    tool_msg = "\n\n".join(lines)
 
-                from codechat.models import ChatMessage
-                work_req.history.append(ChatMessage(role="assistant", content=tool_msg))
-                work_req.message = "Continue."
+                    from codechat.models import ChatMessage
+                    work_req.history.append(ChatMessage(role="assistant", content=tool_msg))
+                    work_req.message = "Continue."
 
-            # Stream out final_text in small chunks
-            if not final_text:
+                # Stream out final_text in small chunks
+                if not final_text:
+                    yield json.dumps({"token": "", "finish": True})
+                    return
+                chunk_size = 200
+                for i in range(0, len(final_text), chunk_size):
+                    yield json.dumps({"token": final_text[i:i+chunk_size], "finish": False})
                 yield json.dumps({"token": "", "finish": True})
-                return
-            chunk_size = 200
-            for i in range(0, len(final_text), chunk_size):
-                yield json.dumps({"token": final_text[i:i+chunk_size], "finish": False})
-            yield json.dumps({"token": "", "finish": True})
         except Exception as e:
             logger.error("Unexpected error during stream_with_functions", exception=str(e), exc_info=True)
             yield json.dumps({"error": True, "message": "An internal server error occurred during streaming.", "finish": True})
@@ -200,43 +200,43 @@ class LLMRouter:
             # Iterative loop
             max_steps = 3
             steps = 0
-            executor = FunctionExecutor()
-            ctx = ExecutionContext(root=self.indexer.root)
+            with FunctionExecutor() as executor:
+                ctx = ExecutionContext(root=self.indexer.root)
 
-            # Prepare a working copy we can mutate
-            from copy import deepcopy
-            work_req = deepcopy(req)
+                # Prepare a working copy we can mutate
+                from copy import deepcopy
+                work_req = deepcopy(req)
 
-            while steps < max_steps:
-                steps += 1
-                result = provider_instance.invoke_with_tools(work_req, functions)  # type: ignore[attr-defined]
+                while steps < max_steps:
+                    steps += 1
+                    result = provider_instance.invoke_with_tools(work_req, functions)  # type: ignore[attr-defined]
 
-                # If provider returned normal text, finish
-                if "function_calls" not in result:
-                    return result
+                    # If provider returned normal text, finish
+                    if "function_calls" not in result:
+                        return result
 
-                calls: list[FunctionCall] = result["function_calls"]
-                if not calls:
-                    return {"text": ""}
+                    calls: list[FunctionCall] = result["function_calls"]
+                    if not calls:
+                        return {"text": ""}
 
-                # Execute calls and append a concise assistant message with outputs
-                lines: list[str] = []
-                for call in calls:
-                    res = executor.execute_function(call, ctx)
-                    if res.success:
-                        lines.append(f"[{res.name}]\n{res.output}")
-                    else:
-                        lines.append(f"[{res.name}] ERROR: {res.error}")
-                tool_msg = "\n\n".join(lines)
+                    # Execute calls and append a concise assistant message with outputs
+                    lines: list[str] = []
+                    for call in calls:
+                        res = executor.execute_function(call, ctx)
+                        if res.success:
+                            lines.append(f"[{res.name}]\n{res.output}")
+                        else:
+                            lines.append(f"[{res.name}] ERROR: {res.error}")
+                    tool_msg = "\n\n".join(lines)
 
-                # Append tool results as assistant message and prompt the model to continue
-                from codechat.models import ChatMessage
-                work_req.history.append(ChatMessage(role="assistant", content=tool_msg))
-                work_req.message = "Continue."
+                    # Append tool results as assistant message and prompt the model to continue
+                    from codechat.models import ChatMessage
+                    work_req.history.append(ChatMessage(role="assistant", content=tool_msg))
+                    work_req.message = "Continue."
 
-            # Exceeded max steps; return what we have
-            logger.info("Max function-call steps reached", steps=steps)
-            return {"text": "Stopped after maximum tool-use steps."}
+                # Exceeded max steps; return what we have
+                logger.info("Max function-call steps reached", steps=steps)
+                return {"text": "Stopped after maximum tool-use steps."}
         except HTTPException:
             raise
         except Exception as e:

--- a/daemon/tests/unit/test_executor_shutdown.py
+++ b/daemon/tests/unit/test_executor_shutdown.py
@@ -1,0 +1,70 @@
+import threading
+from pathlib import Path
+
+from codechat.llm_router import LLMRouter
+from codechat.models import QueryRequest, ProviderType, ChatMessage
+from codechat.functions.models import FunctionDefinition, FunctionCall
+from codechat import providers
+from codechat.functions.executor import FunctionExecutor
+
+
+class _FakeIndexer:
+    def __init__(self, root: Path):
+        self.root = root
+        class _DG:
+            def get_direct_dependencies(self, p):
+                return set()
+            def get_direct_dependents(self, p):
+                return set()
+            def get_all_dependencies(self, p):
+                return set()
+            def get_all_dependents(self, p):
+                return set()
+        self.dgraph = _DG()
+    def query(self, text: str, top_k: int = 5):
+        return []
+
+
+class _StubProvider:
+    name = "openai"
+    def __init__(self):
+        self._called = 0
+    def send(self, req: QueryRequest) -> dict:
+        return {"text": "stub"}
+    async def stream(self, req: QueryRequest):
+        yield "{}"
+    def invoke_with_tools(self, req: QueryRequest, functions: list[FunctionDefinition]) -> dict:
+        self._called += 1
+        if self._called == 1:
+            return {"function_calls": [FunctionCall(name="read_file", arguments={"path": "data.txt"})]}
+        return {"text": "done"}
+
+
+def _count_threads() -> int:
+    return len([t for t in threading.enumerate() if t.name.startswith("ThreadPoolExecutor")])
+
+
+def test_executor_context_manager_closes_threads():
+    before = _count_threads()
+    with FunctionExecutor() as ex:
+        future = ex._pool.submit(lambda: None)
+        future.result()
+    after = _count_threads()
+    assert after == before
+
+
+def test_llm_router_no_thread_leak(tmp_path: Path):
+    f = tmp_path / "data.txt"
+    f.write_text("hi", encoding="utf-8")
+    router = LLMRouter(_FakeIndexer(tmp_path))
+    stub = _StubProvider()
+    orig = providers.get("openai")
+    providers.register(stub)
+    req = QueryRequest(provider=ProviderType.OPENAI, model="gpt-test", history=[ChatMessage(role="user", content="hi")], message="Use tools.")
+    before = _count_threads()
+    try:
+        router.process_request_with_functions(req)
+    finally:
+        providers.register(orig)
+    after = _count_threads()
+    assert after == before

--- a/daemon/tests/unit/test_functions_m1.py
+++ b/daemon/tests/unit/test_functions_m1.py
@@ -18,20 +18,18 @@ def test_read_file_success(tmp_path: Path):
     p.write_text("hello world", encoding="utf-8")
 
     ctx = ExecutionContext(root=tmp_path)
-    executor = FunctionExecutor()
-    call = FunctionCall(name="read_file", arguments={"path": "hello.txt"})
-
-    res = executor.execute_function(call, ctx)
+    with FunctionExecutor() as executor:
+        call = FunctionCall(name="read_file", arguments={"path": "hello.txt"})
+        res = executor.execute_function(call, ctx)
     assert res.success
     assert "hello world" in str(res.output)
 
 
 def test_read_file_prevents_escape(tmp_path: Path):
     ctx = ExecutionContext(root=tmp_path)
-    executor = FunctionExecutor()
-    call = FunctionCall(name="read_file", arguments={"path": "../outside.txt"})
-
-    res = executor.execute_function(call, ctx)
+    with FunctionExecutor() as executor:
+        call = FunctionCall(name="read_file", arguments={"path": "../outside.txt"})
+        res = executor.execute_function(call, ctx)
     assert not res.success
     assert "escape" in (res.error or "") or "Absolute" in (res.error or "")
 
@@ -41,10 +39,9 @@ def test_read_file_max_bytes(tmp_path: Path):
     p.write_text("abcdefghij", encoding="utf-8")  # 10 bytes ASCII
 
     ctx = ExecutionContext(root=tmp_path)
-    executor = FunctionExecutor()
-    call = FunctionCall(name="read_file", arguments={"path": "data.txt", "max_bytes": 5})
-
-    res = executor.execute_function(call, ctx)
+    with FunctionExecutor() as executor:
+        call = FunctionCall(name="read_file", arguments={"path": "data.txt", "max_bytes": 5})
+        res = executor.execute_function(call, ctx)
     assert res.success
     assert str(res.output) == "abcde"
 


### PR DESCRIPTION
## Summary
- add close(), context manager, and __del__ to FunctionExecutor
- use FunctionExecutor as a context manager in LLMRouter
- add tests to ensure thread pools are cleaned up

## Testing
- `poetry run ruff check`
- `poetry run mypy codechat`
- `PYTHONPATH=$PWD poetry run pytest tests/unit/test_executor_shutdown.py tests/unit/test_functions_m1.py`
- `PYTHONPATH=$PWD poetry run pytest` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2847f0d8483339a1d2b67c882623e