### PR TITLE
Add configurable file snippet limit

### DIFF
--- a/daemon/codechat/llm_router.py
+++ b/daemon/codechat/llm_router.py
@@ -29,19 +29,19 @@ class LLMRouter:
         try:
             file_path_obj = Path(file_path_str)
             size = file_path_obj.stat().st_size
-            truncated = False
-            if size > self.max_snippet_bytes:
-                logger.warning(
-                    "File exceeds size limit; truncating for snippet.",
-                    path=file_path_str,
-                    size=size,
-                    limit=self.max_snippet_bytes,
-                )
-                with file_path_obj.open("r", encoding="utf-8", errors="ignore") as f:
-                    file_content = f.read(self.max_snippet_bytes)
-                truncated = True
-            else:
-                file_content = file_path_obj.read_text(encoding="utf-8")
+            truncated = size > self.max_snippet_bytes
+            with file_path_obj.open("rb") as f:
+                if truncated:
+                    logger.warning(
+                        "File exceeds size limit; truncating for snippet.",
+                        path=file_path_str,
+                        size=size,
+                        limit=self.max_snippet_bytes,
+                    )
+                    file_bytes = f.read(self.max_snippet_bytes)
+                else:
+                    file_bytes = f.read()
+            file_content = file_bytes.decode("utf-8", errors="ignore")
             content = f"# File: {file_path_obj.name}\n# Path: {file_path_str}\n\n{file_content}"
             if truncated:
                 content += "\n\n# [truncated]"

--- a/daemon/codechat/llm_router.py
+++ b/daemon/codechat/llm_router.py
@@ -1,11 +1,12 @@
 from pathlib import Path
 from fastapi import HTTPException
 from codechat.models import QueryRequest, Snippet, SnippetType
-import json 
+import json
 from codechat.providers import get as get_provider
-from codechat.indexer import Indexer # Import Indexer
+from codechat.indexer import Indexer  # Import Indexer
 from codechat.functions import get_global_registry, FunctionExecutor
 from codechat.functions.models import ExecutionContext, FunctionCall
+from codechat.config import get_config
 
 import structlog
 logger = structlog.get_logger(__name__)
@@ -13,7 +14,12 @@ logger = structlog.get_logger(__name__)
 class LLMRouter:
     def __init__(self, indexer: Indexer):
         self.indexer = indexer
+        self.reload_config()
         from codechat import providers  # noqa: F401 auto‑import side‑effects
+
+    def reload_config(self) -> None:
+        cfg = get_config()
+        self.max_snippet_bytes = int(cfg.get("router.max_snippet_bytes", 1_000_000))
 
     def _create_snippet_from_file_path(self, file_path_str: str, source_description: str) -> Snippet | None:
         """
@@ -22,9 +28,23 @@ class LLMRouter:
         """
         try:
             file_path_obj = Path(file_path_str)
-            file_content = file_path_obj.read_text(encoding="utf-8")
-            # Using file_path_str for the original path as provided
+            size = file_path_obj.stat().st_size
+            truncated = False
+            if size > self.max_snippet_bytes:
+                logger.warning(
+                    "File exceeds size limit; truncating for snippet.",
+                    path=file_path_str,
+                    size=size,
+                    limit=self.max_snippet_bytes,
+                )
+                with file_path_obj.open("r", encoding="utf-8", errors="ignore") as f:
+                    file_content = f.read(self.max_snippet_bytes)
+                truncated = True
+            else:
+                file_content = file_path_obj.read_text(encoding="utf-8")
             content = f"# File: {file_path_obj.name}\n# Path: {file_path_str}\n\n{file_content}"
+            if truncated:
+                content += "\n\n# [truncated]"
             return Snippet(type=SnippetType.FILE, content=content)
         except UnicodeDecodeError:
             logger.warning(f"Could not decode {source_description} file as UTF-8. Skipping.", path=file_path_str)

--- a/daemon/codechat/server.py
+++ b/daemon/codechat/server.py
@@ -80,7 +80,8 @@ async def reload_config():
     logger = structlog.get_logger("server.reload_config")
     try:
         logger.info("Reloading configuration.")
-        set_config() # Call set_config on the existing instance
+        set_config()  # Reload global configuration
+        router.reload_config()
         logger.info("Configuration reloaded.")
         return {"message": "Configuration reloaded successfully"}
     except Exception as e:

--- a/daemon/tests/unit/test_llm_router_file_limit.py
+++ b/daemon/tests/unit/test_llm_router_file_limit.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from codechat.llm_router import LLMRouter
+from codechat.config import get_config
+
+
+class _FakeIndexer:
+    def __init__(self, root: Path):
+        self.root = root
+
+    def query(self, text: str, top_k: int = 5):
+        return []
+
+
+def test_create_snippet_truncates_large_file(tmp_path: Path):
+    big = tmp_path / "big.txt"
+    big.write_text("a" * 2000, encoding="utf-8")
+
+    cfg = get_config()
+    cfg["router.max_snippet_bytes"] = 100
+
+    router = LLMRouter(_FakeIndexer(tmp_path))
+    snippet = router._create_snippet_from_file_path(str(big), "test")
+
+    assert snippet is not None
+    assert "a" * 100 in snippet.content
+    assert "a" * 101 not in snippet.content
+    assert "[truncated]" in snippet.content

--- a/daemon/tests/unit/test_llm_router_file_limit.py
+++ b/daemon/tests/unit/test_llm_router_file_limit.py
@@ -17,10 +17,16 @@ def test_create_snippet_truncates_large_file(tmp_path: Path):
     big.write_text("a" * 2000, encoding="utf-8")
 
     cfg = get_config()
+    prev = cfg.get("router.max_snippet_bytes")
     cfg["router.max_snippet_bytes"] = 100
-
-    router = LLMRouter(_FakeIndexer(tmp_path))
-    snippet = router._create_snippet_from_file_path(str(big), "test")
+    try:
+        router = LLMRouter(_FakeIndexer(tmp_path))
+        snippet = router._create_snippet_from_file_path(str(big), "test")
+    finally:
+        if prev is None:
+            cfg.pop("router.max_snippet_bytes", None)
+        else:
+            cfg["router.max_snippet_bytes"] = prev
 
     assert snippet is not None
     assert "a" * 100 in snippet.content


### PR DESCRIPTION
## Summary
- limit file snippet size using configurable `router.max_snippet_bytes`
- reload router config on demand
- test truncation of oversized files

## Testing
- `poetry run ruff check`
- `poetry run mypy codechat`
- `poetry run python -m pytest tests/unit/test_llm_router_file_limit.py`
- `poetry run python -m pytest` *(fails: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', port=443): Max retries exceeded with url: ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c27a8b03788333ac98feb9f6af88d6