### PR TITLE
Emit SSE events for streaming tokens

### DIFF
--- a/daemon/codechat/server.py
+++ b/daemon/codechat/server.py
@@ -51,20 +51,20 @@ def health_check():
 async def handle_query(query: QueryRequest, stream: bool = Query(default=False), tools: bool = Query(default=False)):
     if stream:
         async def event_stream():
-            if tools:
-                async for chunk in router.stream_with_functions(query):
-                    chunkjson = json.loads(chunk)
-                    if chunkjson.get("token"):
-                        yield chunkjson.get("token")
-                return
-            async for chunk in router.stream(query):
-                #convert chunk back to json
-                chunkjson = json.loads(chunk)
-                if chunkjson.get("token"):
-                    yield chunkjson.get("token")
+            try:
+                generator = (
+                    router.stream_with_functions(query)
+                    if tools
+                    else router.stream(query)
+                )
+                async for chunk in generator:
+                    payload = chunk if isinstance(chunk, str) else json.dumps(chunk)
+                    yield f"data: {payload}\n\n"
+            except Exception as e:
+                error_payload = json.dumps({"error": str(e), "finish": True})
+                yield f"data: {error_payload}\n\n"
 
-        return StreamingResponse(event_stream(),
-                                 media_type="text/event-stream")
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
     if tools:
         result = router.process_request_with_functions(query)
     else:

--- a/daemon/codechat/server.py
+++ b/daemon/codechat/server.py
@@ -69,7 +69,14 @@ async def handle_query(query: QueryRequest, stream: bool = Query(default=False),
         result = router.process_request_with_functions(query)
     else:
         result = router.route(query)
-    return result.get("text")
+
+    text = result.get("text")
+    if text is None:
+        err = HTTPException(status_code=500, detail="Provider response missing 'text' field")
+        err.code = "INVALID_PROVIDER_RESPONSE"  # type: ignore[attr-defined]
+        raise err
+
+    return text
 
 
 @app.post("/admin/reload-config")

--- a/daemon/tests/integration/test_server_endpoints.py
+++ b/daemon/tests/integration/test_server_endpoints.py
@@ -1,6 +1,7 @@
 # tests/integration/test_server_endpoints.py
-import json
 import importlib
+import json
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -82,3 +83,20 @@ def test_stream_sse_error(client, server_module, monkeypatch):
 
     assert events[-1]["error"] == "boom"
     assert events[-1]["finish"] is True
+
+
+def test_provider_missing_text_error(client, monkeypatch):
+    def fake_route(query):
+        return {}
+
+    monkeypatch.setattr("codechat.server.router.route", fake_route)
+
+    req = {
+        "provider": "openai",
+        "model": "gpt-4",
+        "message": "hello",
+    }
+    res = client.post("/query", json=req)
+    assert res.status_code == 500
+    payload = res.json()
+    assert payload["error"]["code"] == "INVALID_PROVIDER_RESPONSE"

--- a/daemon/tests/integration/test_server_endpoints.py
+++ b/daemon/tests/integration/test_server_endpoints.py
@@ -1,11 +1,22 @@
 # tests/integration/test_server_endpoints.py
+import json
+import importlib
 import pytest
 from fastapi.testclient import TestClient
-from codechat.server import app
 
-@pytest.fixture(scope="module")
-def client():
-    return TestClient(app)
+
+@pytest.fixture()
+def server_module(monkeypatch):
+    import codechat.indexer as indexer_module
+    monkeypatch.setattr(indexer_module.Indexer, "build_index", lambda self: None)
+    server = importlib.import_module("codechat.server")
+    monkeypatch.setattr(server.watcher, "start", lambda: None)
+    return server
+
+
+@pytest.fixture()
+def client(server_module):
+    return TestClient(server_module.app)
 
 def test_health_ok(client):
     assert client.get("/health").json() == {"status": "ok"}
@@ -15,3 +26,59 @@ def test_validation_error(client):
     assert res.status_code == 422
     payload = res.json()
     assert payload["error"]["code"] == "VALIDATION_ERR"
+
+
+def test_stream_sse(client, server_module, monkeypatch):
+    async def fake_stream(_: server_module.QueryRequest):
+        for chunk in [
+            json.dumps({"token": "hello", "finish": False}),
+            json.dumps({"token": " world", "finish": False}),
+            json.dumps({"token": "", "finish": True}),
+        ]:
+            yield chunk
+
+    monkeypatch.setattr(server_module.router, "stream", fake_stream)
+
+    payload = {
+        "provider": "openai",
+        "model": "gpt-test",
+        "history": [],
+        "message": "hi",
+    }
+
+    with client.stream("POST", "/query?stream=true", json=payload) as res:
+        events = []
+        for line in res.iter_lines():
+            if line:
+                assert line.startswith("data: ")
+                events.append(json.loads(line[6:]))
+
+    text = "".join(e.get("token", "") for e in events)
+    assert text == "hello world"
+    assert events[-1]["finish"] is True
+
+
+def test_stream_sse_error(client, server_module, monkeypatch):
+    async def fake_stream(_: server_module.QueryRequest):
+        if False:
+            yield ""  # pragma: no cover
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(server_module.router, "stream", fake_stream)
+
+    payload = {
+        "provider": "openai",
+        "model": "gpt-test",
+        "history": [],
+        "message": "hi",
+    }
+
+    with client.stream("POST", "/query?stream=true", json=payload) as res:
+        events = []
+        for line in res.iter_lines():
+            if line:
+                assert line.startswith("data: ")
+                events.append(json.loads(line[6:]))
+
+    assert events[-1]["error"] == "boom"
+    assert events[-1]["finish"] is True


### PR DESCRIPTION
## Summary
- wrap router streaming output in Server-Sent Events frames
- stream error messages and completion flags as SSE
- adjust integration tests to parse SSE frames and cover error path

## Testing
- `poetry run ruff check`
- `poetry run mypy codechat`
- `PYTHONPATH=. poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c284a14f548333b1e2b327536410f4