### PR TITLE
Validate provider responses in query endpoint

### DIFF
--- a/daemon/codechat/server.py
+++ b/daemon/codechat/server.py
@@ -69,7 +69,14 @@ async def handle_query(query: QueryRequest, stream: bool = Query(default=False),
         result = router.process_request_with_functions(query)
     else:
         result = router.route(query)
-    return result.get("text")
+
+    text = result.get("text")
+    if text is None:
+        err = HTTPException(status_code=500, detail="Provider response missing 'text' field")
+        err.code = "INVALID_PROVIDER_RESPONSE"  # type: ignore[attr-defined]
+        raise err
+
+    return text
 
 
 @app.post("/admin/reload-config")

--- a/daemon/tests/integration/test_server_endpoints.py
+++ b/daemon/tests/integration/test_server_endpoints.py
@@ -15,3 +15,20 @@ def test_validation_error(client):
     assert res.status_code == 422
     payload = res.json()
     assert payload["error"]["code"] == "VALIDATION_ERR"
+
+
+def test_provider_missing_text_error(client, monkeypatch):
+    def fake_route(query):
+        return {}
+
+    monkeypatch.setattr("codechat.server.router.route", fake_route)
+
+    req = {
+        "provider": "openai",
+        "model": "gpt-4",
+        "message": "hello"
+    }
+    res = client.post("/query", json=req)
+    assert res.status_code == 500
+    payload = res.json()
+    assert payload["error"]["code"] == "INVALID_PROVIDER_RESPONSE"

--- a/docs/QueryResponseShape.md
+++ b/docs/QueryResponseShape.md
@@ -1,0 +1,18 @@
+# Query Response Shape
+
+`POST /query` returns the text produced by the provider as a plain string.
+
+```json
+"Hello from CodeChat"
+```
+
+If the underlying provider result is missing the `text` field, the server returns an error envelope:
+
+```json
+{
+  "error": {
+    "code": "INVALID_PROVIDER_RESPONSE",
+    "msg": "Provider response missing 'text' field"
+  }
+}
+```


### PR DESCRIPTION
## Summary
- ensure /query validates provider response and raises INVALID_PROVIDER_RESPONSE when `text` is missing
- document expected /query response shape
- test server behavior when provider omits `text`

## Testing
- `poetry run ruff check`
- `poetry run mypy codechat`
- `PYTHONPATH=. poetry run pytest` *(fails: requests.exceptions.ProxyError: HTTPSConnectionPool(host='openaipublic.blob.core.windows.net', ...))*

------
https://chatgpt.com/codex/tasks/task_e_68c2849288fc8333a86003cd707a1b62