### PR TITLE
Revert function-call merge changes and restore query validation

### DIFF
--- a/daemon/codechat/server.py
+++ b/daemon/codechat/server.py
@@ -69,7 +69,14 @@ async def handle_query(query: QueryRequest, stream: bool = Query(default=False),
         result = router.process_request_with_functions(query)
     else:
         result = router.route(query)
-    return result.get("text")
+
+    text = result.get("text")
+    if text is None:
+        err = HTTPException(status_code=500, detail="Provider response missing 'text' field")
+        err.code = "INVALID_PROVIDER_RESPONSE"  # type: ignore[attr-defined]
+        raise err
+
+    return text
 
 
 @app.post("/admin/reload-config")

--- a/daemon/tests/integration/test_server_endpoints.py
+++ b/daemon/tests/integration/test_server_endpoints.py
@@ -1,6 +1,7 @@
 # tests/integration/test_server_endpoints.py
-import json
 import importlib
+import json
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -82,3 +83,20 @@ def test_stream_sse_error(client, server_module, monkeypatch):
 
     assert events[-1]["error"] == "boom"
     assert events[-1]["finish"] is True
+
+
+def test_provider_missing_text_error(client, monkeypatch):
+    def fake_route(query):
+        return {}
+
+    monkeypatch.setattr("codechat.server.router.route", fake_route)
+
+    req = {
+        "provider": "openai",
+        "model": "gpt-4",
+        "message": "hello",
+    }
+    res = client.post("/query", json=req)
+    assert res.status_code == 500
+    payload = res.json()
+    assert payload["error"]["code"] == "INVALID_PROVIDER_RESPONSE"


### PR DESCRIPTION
## Summary
- revert the previous "Resolve merge conflict in integration tests" commit to drop unintended function-call and docs changes
- restore the `/query` handler's guard for missing provider text and keep the SSE plus provider error integration coverage

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca83c9d840833386fc4d7cdd483ce8